### PR TITLE
ENH: new date-based versioning; standardized license/copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME Development Team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of qiime2 nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/app/index.html.handlebars
+++ b/app/index.html.handlebars
@@ -1,5 +1,5 @@
 {{!--------------------------------------------------------------------------
-   Copyright (c) 2016--, QIIME development team.
+   Copyright (c) 2016-2017, QIIME 2 development team.
 
    Distributed under the terms of the Modified BSD License.
 

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/eslint.yaml
+++ b/config/eslint.yaml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/config/stylelint.yaml
+++ b/config/stylelint.yaml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/webpack.shared.js
+++ b/config/webpack.shared.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q2view",
-  "version": "0.0.1",
+  "version": "2017.2.0-dev0",
   "description": "View QIIME 2 Artifacts on the web!",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/qiime2/q2view.git"
   },
-  "author": "QIIME 2 Development Team",
+  "author": "QIIME 2 development team",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/qiime2/q2view/issues"


### PR DESCRIPTION
New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0,
  2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in
setup.py's `install_requires` to obtain patch releases for a given train
release.

The new versioning scheme is PEP 440 compliant.

Standardized LICENSE and copyright headers in source files.