### PR TITLE
ENH: remove heartbeat hack

### DIFF
--- a/app/init/session.js
+++ b/app/init/session.js
@@ -1,10 +1,9 @@
 import { updateLoadMessage } from '../Loader/dux';
-import { getReader, getServiceWorker } from './dux';
+import { getReader } from './dux';
 
 export default () => (dispatch, getState) => {
     dispatch(updateLoadMessage('initializing loopback session'));
-    const state = getState();
-    const reader = getReader(state);
-    const sw = getServiceWorker(state);
-    return reader.attachToServiceWorker(sw);
+    const reader = getReader(getState());
+    reader.attachToServiceWorker();
+    return Promise.resolve(true);
 };

--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -6,25 +6,12 @@
 // The full license is in the file LICENSE, distributed with this software.
 // ----------------------------------------------------------------------------
 
-const sessions = {};
-
 self.addEventListener('install', (event) => {
     event.waitUntil(self.skipWaiting()); // Activate worker immediately
 });
 
 self.addEventListener('activate', (event) => {
     event.waitUntil(self.clients.claim()); // Become available to all pages
-});
-
-self.addEventListener('message', (event) => {
-    switch (event.data.type) {
-    case 'NEW_DOCUMENT':
-        sessions[event.data.session] = event.ports[0];
-        event.ports[0].postMessage(event.data);
-        break;
-    default:
-        return;
-    }
 });
 
 self.addEventListener('fetch', (fetchEvent) => {
@@ -36,14 +23,16 @@ self.addEventListener('fetch', (fetchEvent) => {
 
     const components = url.pathname.split('/').slice(2);  // discard '' and '_'
     const session = components[0];
+    const uuid = components[1];
     const filename = components.slice(2).join('/');  // everything but session/uuid
 
     fetchEvent.respondWith(new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
-        const channel = new MessageChannel();
-        channel.port1.onmessage = (event) => {
-            resolve(new Response(event.data));
-        };
+        self.clients.matchAll().then(clients => clients.forEach((client) => {
+            const channel = new MessageChannel();
+            channel.port1.onmessage = event => resolve(new Response(event.data));
 
-        sessions[session].postMessage({ type: 'GET_BLOB', filename }, [channel.port2]);
+            client.postMessage({ type: 'GET_BLOB', session, uuid, filename },
+                               [channel.port2]);
+        }));
     }));
 });


### PR DESCRIPTION
The code is simpler and doesn't need any timeout-hacks!

Instead of having each page "ping" the service worker to keep it's global scope alive, the service worker instead asks every client to provide the payload of the fetch request. Each client page just filters out messages which don't match their session.