### PR TITLE
BUG: unique ids for edges from different inputs of same uuid

### DIFF
--- a/app/init/provenance.js
+++ b/app/init/provenance.js
@@ -29,7 +29,7 @@ export default () => (dispatch, getState) => {
             for (const mapping of actions[actionUUID]) {
                 edges.push({
                     data: {
-                        id: `${Object.values(mapping)[0]}to${actionUUID}`,
+                        id: `${Object.keys(mapping)[0]}_${Object.values(mapping)[0]}to${actionUUID}`,
                         param: Object.keys(mapping)[0],
                         source: Object.values(mapping)[0],
                         target: actionUUID


### PR DESCRIPTION
If the same artifact is provided twice, only one edge was drawn because they had the same ID. Now they are both drawn (albeit on top of each other, but at least it clearly looks weird to suggest further inspection).

![image](https://user-images.githubusercontent.com/3976804/27157418-3f72cdbc-5116-11e7-973a-2f44caae175d.png)
