### PR TITLE
MAINT: re-arrange blob construction to avoid Firefox regression

### DIFF
--- a/app/lib/reader.js
+++ b/app/lib/reader.js
@@ -76,10 +76,10 @@ export default class Reader {
                 return; // This message is meant for another tab.
             }
             switch (event.data.type) {
-            case 'GET_BLOB':
-                this._getFile(event.data.filename).then((blob) => {
+            case 'GET_DATA':
+                this._getFile(event.data.filename).then((data) => {
                     // the request should provide a port for later response
-                    event.ports[0].postMessage(blob);
+                    event.ports[0].postMessage(data);
                 }).catch(error => console.error(error));  // eslint-disable-line no-console
                 break;
             default:
@@ -98,13 +98,16 @@ export default class Reader {
         } else {
             filepromise = () => filehandle.async('uint8array');
         }
-        return filepromise().then(byteArray => (
-            new Blob([byteArray], { type: extmap[ext] || '' })
-        ));
+        return filepromise().then(byteArray => ({
+            byteArray,
+            type: extmap[ext] || ''
+        }));
     }
 
     _getYAML(relpath) {
-        return this._getFile(relpath).then(readBlobAsText)
+        return this._getFile(relpath)
+                   .then(data => new Blob([data.byteArray], { type: data.type }))
+                   .then(readBlobAsText)
                    .then(text => yaml.safeLoad(text, { schema }));
     }
 

--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -34,9 +34,12 @@ self.addEventListener('fetch', (fetchEvent) => {
     fetchEvent.respondWith(new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
         self.clients.matchAll().then(clients => clients.forEach((client) => {
             const channel = new MessageChannel();
-            channel.port1.onmessage = event => resolve(new Response(event.data));
+            channel.port1.onmessage = (event) => {
+                const blob = new Blob([event.data.byteArray], { type: event.data.type });
+                resolve(new Response(blob));
+            };
 
-            client.postMessage({ type: 'GET_BLOB', session, uuid, filename },
+            client.postMessage({ type: 'GET_DATA', session, uuid, filename },
                                [channel.port2]);
         }));
     }));


### PR DESCRIPTION
This changes the service worker, so we'll want to roll this out at night because of gh-pages (and cloudflare) caching.