### PR TITLE
BUG: fix protocol-violation in FF

### DIFF
--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -17,7 +17,6 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (fetchEvent) => {
     const url = new URL(fetchEvent.request.url);
     if (!url.pathname.startsWith('/_/')) {
-        fetchEvent.respondWith(fetch(fetchEvent.request));
         return; // end of fetch
     }
 


### PR DESCRIPTION
When clicking on links for the first time in a new session, FF wouldn't load anything and show a protocol violation right away. I think this has to do with redirect-mode on fetch which keeps changing on the spec, but there's really no reason for the service worker to proxy these fetches in the first place. So now the service worker now just skips requests that don't belong to it.