### PR TITLE
ENH: add content-disposition for unknown filetypes

### DIFF
--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -36,7 +36,12 @@ self.addEventListener('fetch', (fetchEvent) => {
             const channel = new MessageChannel();
             channel.port1.onmessage = (event) => {
                 const blob = new Blob([event.data.byteArray], { type: event.data.type });
-                resolve(new Response(blob));
+                const init = {};
+                if (!event.data.type) {
+                    // unkown extension, so invoke download dialog
+                    init.headers = { 'Content-Disposition': 'attachment' };
+                }
+                resolve(new Response(blob, init));
             };
 
             client.postMessage({ type: 'GET_DATA', session, uuid, filename },

--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -38,7 +38,7 @@ self.addEventListener('fetch', (fetchEvent) => {
                 const blob = new Blob([event.data.byteArray], { type: event.data.type });
                 const init = {};
                 if (!event.data.type) {
-                    // unkown extension, so invoke download dialog
+                    // unknown extension, so invoke download dialog
                     init.headers = { 'Content-Disposition': 'attachment' };
                 }
                 resolve(new Response(blob, init));


### PR DESCRIPTION
This means links that open to something like a `*.fasta` file will prompt the download dialog.