### PR TITLE
Revert "MAINT: use data.qiime2.org gallery links"

### DIFF
--- a/app/pages/Home/Gallery.jsx
+++ b/app/pages/Home/Gallery.jsx
@@ -17,7 +17,8 @@ export default () => (
                 <p style={{ textAlign: 'right' }}>
                     <Button
                         bsStyle="primary"
-                        href={'/?type=html&src=https%3A%2F%2Fdata.qiime2.org%2Fgallery%2Ftaxa-bar-plots.qzv'}
+                        href={'/?type=html&src=https%3A%2F%2Fdocs.qiime2.org%2F2017.5%2Fdata%2F' +
+                              'tutorials%2Fmoving-pictures%2Ftaxa-bar-plots.qzv'}
                     >Try it!</Button>
                 </p>
             </Thumbnail>
@@ -32,7 +33,8 @@ export default () => (
                 <p style={{ textAlign: 'right' }}>
                     <Button
                         bsStyle="primary"
-                        href={'/?type=html&src=https%3A%2F%2Fdata.qiime2.org%2Fgallery%2Ftable.qzv'}
+                        href={'/?type=html&src=https%3A%2F%2Fdocs.qiime2.org%2F2017.5%2Fdata%2F' +
+                              'tutorials%2Fmoving-pictures%2Ftable.qzv'}
                     >Try it!</Button>
                 </p>
             </Thumbnail>
@@ -47,7 +49,9 @@ export default () => (
                 <p style={{ textAlign: 'right' }}>
                     <Button
                         bsStyle="primary"
-                        href={'/?type=html&src=https%3A%2F%2Fdata.qiime2.org%2Fgallery%2Funweighted-unifrac-emperor.qzv'}
+                        href={'/?type=html&src=https%3A%2F%2Fdocs.qiime2.org%2F2017.5%2Fdata%2F' +
+                              'tutorials%2Fmoving-pictures%2Fcore-metrics-results%2Funweighted-' +
+                              'unifrac-emperor.qzv'}
                     >Try it!</Button>
                 </p>
             </Thumbnail>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q2view",
-  "version": "0.0.0",
+  "version": "2017.6.0-dev0",
   "description": "View QIIME 2 Artifacts on the web!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reverts qiime2/q2view#71

q2view doesn't work with redirects so we can't use data.qiime2.org links. We'll keep going with the current strategy (pointing to versioned docs.qiime2.org URLs) and think about streamlining this process in the future.