### PR TITLE
Remove range check and size limit on requests

### DIFF
--- a/app/init/resolve.js
+++ b/app/init/resolve.js
@@ -18,11 +18,10 @@ export const resolveURL = () => (dispatch, getState) => {
 
     return fetch(rawSrc.data, { method: 'HEAD', mode: 'cors' })
         .then((response) => {
-            if (response.ok) {
-                return fetch(rawSrc.data).then(res => res.blob());
-            } else {
+            if (!response.ok) {
                 throw Error(`Network error, recieved ${response.status} from server.`);
             }
+            return fetch(rawSrc.data).then(res => res.blob());
         }).then(Reader.createReaderFromFile).then((reader) => {
             dispatch(setSource(encodeURIComponent(rawSrc.data)));
             dispatch(setReader(reader));

--- a/app/init/resolve.js
+++ b/app/init/resolve.js
@@ -19,20 +19,7 @@ export const resolveURL = () => (dispatch, getState) => {
     return fetch(rawSrc.data, { method: 'HEAD', mode: 'cors' })
         .then((response) => {
             if (response.ok) {
-                const headers = response.headers;
-                let contentLength = headers.get('Content-Length');
-                // not everyone sets 'Access-Control-Allow-Headers: *' (GitHub pages!)
-                if (contentLength !== null) {
-                    contentLength = parseInt(contentLength, 10);
-                }
-                if (headers.has('Accept-Ranges') && headers.get('Accept-Ranges') === 'bytes') {
-                    // TODO: be smarter with the Ranges header
-                    return fetch(rawSrc.data).then(res => res.blob());
-                } else if (contentLength === null || contentLength <= 15 * 1024 * 1024) {
-                    return fetch(rawSrc.data).then(res => res.blob());
-                }
-                throw Error(`File is too large (${contentLength} bytes) and the` +
-                            ' server does accept the "Ranges" header');
+                return fetch(rawSrc.data).then(res => res.blob());
             } else {
                 throw Error(`Network error, recieved ${response.status} from server.`);
             }


### PR DESCRIPTION
This logic doesn't really do anything useful, may as well drop it until we *can* do something interesting.