### PR TITLE
Add space between sentences on the home page

### DIFF
--- a/app/pages/Home/component.jsx
+++ b/app/pages/Home/component.jsx
@@ -12,8 +12,8 @@ export default ({ submitFile, submitURL, redirectTo }) => (
             <Col md={12}>
                 <p style={{ fontSize: '18px' }}>
                     This interface can view .qza and .qzv files
-                    directly in your browser without uploading to a server. <Link to="/about">Click
-                        here</Link> to learn more.
+                    directly in your browser without uploading to a server.
+                    <span>&nbsp;<Link to="/about">Click here</Link> to learn more.</span>
                 </p>
             </Col>
         </Row>

--- a/app/pages/Home/component.jsx
+++ b/app/pages/Home/component.jsx
@@ -12,8 +12,7 @@ export default ({ submitFile, submitURL, redirectTo }) => (
             <Col md={12}>
                 <p style={{ fontSize: '18px' }}>
                     This interface can view .qza and .qzv files
-                    directly in your browser without uploading to a server.
-                    <Link to="/about">Click here</Link> to learn more.
+                    directly in your browser without uploading to a server. <Link to="/about">Click here</Link> to learn more.
                 </p>
             </Col>
         </Row>

--- a/app/pages/Home/component.jsx
+++ b/app/pages/Home/component.jsx
@@ -12,7 +12,8 @@ export default ({ submitFile, submitURL, redirectTo }) => (
             <Col md={12}>
                 <p style={{ fontSize: '18px' }}>
                     This interface can view .qza and .qzv files
-                    directly in your browser without uploading to a server. <Link to="/about">Click here</Link> to learn more.
+                    directly in your browser without uploading to a server. <Link to="/about">Click
+                        here</Link> to learn more.
                 </p>
             </Col>
         </Row>


### PR DESCRIPTION
Right now there isn't a space between the "... server." and "Click here ..." sentences --

![image](https://user-images.githubusercontent.com/4177727/96944485-c1d87780-148f-11eb-83da-b8a4c95c6b49.png)

This fixes the problem:

![image](https://user-images.githubusercontent.com/4177727/96945464-afac0880-1492-11eb-868d-ecb18f1baf59.png)